### PR TITLE
比较fbuild.exe文件名忽略大小写

### DIFF
--- a/msfastbuildvsix/FASTBuild.cs
+++ b/msfastbuildvsix/FASTBuild.cs
@@ -107,7 +107,7 @@ namespace msfastbuildvsix
 		{
 			string fbuild = "fbuild.exe";
 
-			if (FBuildExePath != fbuild)
+			if (FBuildExePath.ToLower() != fbuild)
 			{
 				return File.Exists(FBuildExePath);
 			}


### PR DESCRIPTION
比较fbuild.exe文件名时，应该忽略大小写